### PR TITLE
Fix infinite connect/disconnect loops

### DIFF
--- a/modules/redis.ts
+++ b/modules/redis.ts
@@ -51,7 +51,7 @@ export class Redis extends Module {
     /**
      * Connecting to the Redis database with the module
      */
-    async connect() {
+    async connectAll() {
         await this.connect();
         await this.rts.connect();
         await this.rejson.connect();
@@ -69,7 +69,7 @@ export class Redis extends Module {
     /**
      * Disconnecting from the Redis database with the module
      */
-    async disconnect() {
+    async disconnectAll() {
         await this.disconnect();
         await this.rts.disconnect();
         await this.rejson.disconnect();


### PR DESCRIPTION
Fixed `connect`/`disconnect` functions using `Redis` aggregator module, by renaming the aggregator function. 
Otherwise it goes for infinite loop, referencing `connect`/`disconnect` itself, which throws `RangeError: Maximum call stack size exceeded` exception.